### PR TITLE
Correctly handle single speed fans

### DIFF
--- a/src/controllers/fan-controller.ts
+++ b/src/controllers/fan-controller.ts
@@ -53,9 +53,14 @@ export class FanController extends Controller {
 
   get iconRotateSpeed(): string {
     let speed = 0;
-    if (this.percentage > 0) {
-      speed = 3 - ((this.percentage / 100) * 2);
+    if (this.hasSlider) {
+      if (this.percentage > 0) {
+        speed = 3 - ((this.percentage / 100) * 2);
+      }
+    } else {
+      speed = this._value
     }
+    
     return `${speed}s`
   }
 

--- a/src/controllers/fan-controller.ts
+++ b/src/controllers/fan-controller.ts
@@ -29,7 +29,7 @@ export class FanController extends Controller {
   }
 
   get _step(): number {
-    return this.stateObj.attributes.percentage_step;
+    return this.hasSlider ? this.stateObj.attributes.percentage_step : 1;
   }
 
   get label(): string {


### PR DESCRIPTION
This allows single speed fans to have an animated icon when they are on and sets the `_step` to 1 (just like a switch).