### PR TITLE
Remove rollup-plugin-uglify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slider-button-card",
-  "version": "1.10.3",
+  "version": "1.10.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2365,26 +2365,6 @@
         }
       }
     },
-    "rollup-plugin-uglify": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz",
-      "integrity": "sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^2.1.2",
-        "uglify-js": "^3.4.9"
-      },
-      "dependencies": {
-        "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-          "dev": true
-        }
-      }
-    },
     "rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -2801,12 +2781,6 @@
       "version": "3.9.9",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
-    },
-    "uglify-js": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
-      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "rollup-plugin-serve": "^1.1.0",
     "rollup-plugin-terser": "^5.3.1",
     "rollup-plugin-typescript2": "^0.24.3",
-    "rollup-plugin-uglify": "^6.0.4",
     "typescript": "^3.9.7"
   },
   "scripts": {


### PR DESCRIPTION
rollup-plugin-uglify has been replaced with rollup-plugin-terser but the dependency wasn't cleaned up. Removing will allow for resolving https://github.com/custom-cards/slider-button-card/security/dependabot/1