### PR TITLE
Fix localization of entity states

### DIFF
--- a/src/controllers/cover-controller.ts
+++ b/src/controllers/cover-controller.ts
@@ -72,9 +72,9 @@ export class CoverController extends Controller {
   }
 
   get label(): string {
-    const defaultLabel = this._hass.localize(`component.cover.state._.${this.state}`);
-    const closedLabel = this._hass.localize('component.cover.state._.closed');
-    const openLabel = this._hass.localize('component.cover.state._.open');
+    const defaultLabel = this._hass.localize(`component.cover.entity_component._.state.${this.state}`);
+    const closedLabel = this._hass.localize('component.cover.entity_component._.state.closed');
+    const openLabel = this._hass.localize('component.cover.entity_component._.state.open');
     if (!this.hasSlider) {
       return defaultLabel;
     }

--- a/src/controllers/fan-controller.ts
+++ b/src/controllers/fan-controller.ts
@@ -37,10 +37,10 @@ export class FanController extends Controller {
       if (this.hasSlider) {
         return `${this.percentage}%`
       } else {
-        return this._hass.localize('component.fan.state._.on');
+        return this._hass.localize('component.fan.entity_component._.state.on');
       }
     }
-    return this._hass.localize('component.fan.state._.off');
+    return this._hass.localize('component.fan.entity_component._.state.off');
   }
 
   get hasSlider(): boolean {

--- a/src/controllers/input-boolean-controller.ts
+++ b/src/controllers/input-boolean-controller.ts
@@ -27,9 +27,9 @@ export class InputBooleanController extends Controller {
 
   get label(): string {
     if (this.percentage > 0) {
-      return this._hass.localize('component.input_boolean.state._.on');
+      return this._hass.localize('component.input_boolean.entity_component._.state.on');
     }
-    return this._hass.localize('component.input_boolean.state._.off');
+    return this._hass.localize('component.input_boolean.entity_component._.state.off');
   }
 
 }

--- a/src/controllers/light-controller.ts
+++ b/src/controllers/light-controller.ts
@@ -181,14 +181,14 @@ export class LightController extends Controller {
 
   get label(): string {
     if (this.isOff) {
-      return this._hass.localize('component.light.state._.off');
+      return this._hass.localize('component.light.entity_component._.state.off');
     }
     if (this.colorMode === LightColorModes.ON_OFF) {
-      return this._hass.localize('component.light.state._.on');
+      return this._hass.localize('component.light.entity_component._.state.on');
     }
     switch(this.attribute) {
       case LightAttributes.ON_OFF:
-        return this._hass.localize('component.light.state._.on');
+        return this._hass.localize('component.light.entity_component._.state.on');
       case LightAttributes.COLOR_TEMP:
       case LightAttributes.BRIGHTNESS:
         return `${this.targetValue}`;

--- a/src/controllers/lock-controller.ts
+++ b/src/controllers/lock-controller.ts
@@ -27,9 +27,9 @@ export class LockController extends Controller {
 
   get label(): string {
     if (this.percentage > 0) {
-      return this._hass.localize('component.lock.state._.unlocked');
+      return this._hass.localize('component.lock.entity_component._.state.unlocked');
     }
-    return this._hass.localize('component.lock.state._.locked');
+    return this._hass.localize('component.lock.entity_component._.state.locked');
   }
 
 }

--- a/src/controllers/switch-controller.ts
+++ b/src/controllers/switch-controller.ts
@@ -27,9 +27,9 @@ export class SwitchController extends Controller {
 
   get label(): string {
     if (this.percentage > 0) {
-      return this._hass.localize('component.switch.state._.on');
+      return this._hass.localize('component.switch.entity_component._.state.on');
     }
-    return this._hass.localize('component.switch.state._.off');
+    return this._hass.localize('component.switch.entity_component._.state.off');
   }
 
 }


### PR DESCRIPTION
Home Assistant 2023.4 changed the translations keys for looking up states. We need to update them here so that the state labels start working again.