### PR TITLE
[feat] Add attribute field and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ Slider Button Card supports Lovelace's Visual Editor.
 | type              | string  | **Required** | `custom:slider-button-card`                   |
 | entity            | string  | **Required** | HA entity ID from domain `light, switch, fan, cover, input_boolean, media_player, climate, lock`                   |               |
 | name              | string  | **Optional** | Name                                   | `entity.friendly_name`       |
+| show_attribute        | boolean | **Optional** | Show attribute  | `false` (except for `media_player` entities)            |
 | show_name        | boolean | **Optional** | Show name  | `true`             |
 | show_state        | boolean | **Optional** | Show state  | `true`             |
 | compact        | boolean | **Optional** | Compact mode, display name and state inline with icon. Useful for full width cards.   | `false`             |
+| attribute     | string  | **Optional** | Name of the attribute to display if `show_attribute` is `true`.
 | icon        | object  | **Optional** |  [Icon options](#icon-options)                      |  |
 | slider        | object  | **Optional** | [Slider options](#slider-options)                      |  |
 | action_button        | object  | **Optional** | [Action button options](#action-button-options)                     |  |

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -91,6 +91,13 @@ export abstract class Controller {
     return `${this.targetValue}`;
   }
 
+  get attributeLabel(): string {
+    if (this._config.attribute) {
+      return this.stateObj.attributes[this._config.attribute];
+    }
+    return '';
+  }
+
   get hidden(): boolean {
     return false;
   }

--- a/src/controllers/media-controller.ts
+++ b/src/controllers/media-controller.ts
@@ -31,11 +31,32 @@ export class MediaController extends Controller {
     return this.stateObj.state === 'off';
   }
 
+/*
+Attributes desired:
+Playstation: source, media_title
+TV: source
+Chromecast: app_name, media_title, media_series, media_...
+  Plex is a bit of an outlier with no media_title
+*/
+
   get label(): string {
-    if (this.stateObj.attributes.is_volume_muted) return '-';
-    return !!this.stateObj.attributes.volume_level
+    let output;
+    let primary_info;
+    let secondary_info;
+
+    if (this.stateObj.attributes.is_volume_muted) primary_info = '-';
+
+    primary_info = !!this.stateObj.attributes.volume_level
       ? `${this.percentage}%`
-      : this._hass.localize(`component.media_player.state._.${this.state}`);
+      : `${this._hass.localize(`component.media_player.state._.${this.state}`)}`;
+
+    secondary_info = this._config.attribute;
+
+    output = primary_info;
+
+    if (secondary_info) output = output + " · " + secondary_info;
+
+    return output;
   }
 
 }

--- a/src/controllers/media-controller.ts
+++ b/src/controllers/media-controller.ts
@@ -31,32 +31,11 @@ export class MediaController extends Controller {
     return this.stateObj.state === 'off';
   }
 
-/*
-Attributes desired:
-Playstation: source, media_title
-TV: source
-Chromecast: app_name, media_title, media_series, media_...
-  Plex is a bit of an outlier with no media_title
-*/
-
   get label(): string {
-    let output;
-    let primary_info;
-    let secondary_info;
-
-    if (this.stateObj.attributes.is_volume_muted) primary_info = '-';
-
-    primary_info = !!this.stateObj.attributes.volume_level
+    if (this.stateObj.attributes.is_volume_muted) return '-';
+    return !!this.stateObj.attributes.volume_level
       ? `${this.percentage}%`
-      : `${this._hass.localize(`component.media_player.state._.${this.state}`)}`;
-
-    secondary_info = this._config.attribute;
-
-    output = primary_info;
-
-    if (secondary_info) output = output + " · " + secondary_info;
-
-    return output;
+      : this._hass.localize(`component.media_player.state._.${this.state}`);
   }
 
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -62,12 +62,20 @@ export class SliderButtonCardEditor extends LitElement implements LovelaceCardEd
     return typeof this._config?.show_state === 'undefined' ? true : this._config?.show_state;
   }
 
+  get _show_attribute(): boolean {
+    return typeof this._config?.show_attribute === 'undefined' ? true : this._config?.show_attribute;
+  }
+
   get _compact(): boolean {
     return typeof this._config?.compact !== 'boolean' ? false : this._config?.compact;
   }
 
   get _entity(): string {
     return this._config?.entity || '';
+  }
+
+  get _attribute(): string {
+    return this._config?.attribute || '';
   }
 
   get _icon(): IconConfig {
@@ -112,6 +120,13 @@ export class SliderButtonCardEditor extends LitElement implements LovelaceCardEd
                 .configValue=${'name'}
                 @value-changed=${this._valueChanged}
               ></paper-input>
+              <paper-input
+                label="${localize('tabs.general.attribute')}"
+                .value=${this._attribute}
+                .placeholder=""
+                .configValue=${'attribute'}
+                @value-changed=${this._valueChanged}
+              ></paper-input>
               <div class="side-by-side">
                 <ha-formfield .label=${localize('tabs.general.show_name')}>
                   <ha-switch
@@ -124,6 +139,13 @@ export class SliderButtonCardEditor extends LitElement implements LovelaceCardEd
                   <ha-switch
                     .checked=${this._show_state}
                     .configValue=${'show_state'}
+                    @change=${this._valueChanged}
+                  ></ha-switch>
+                </ha-formfield>
+                <ha-formfield .label=${localize('tabs.general.show_attribute')}>
+                  <ha-switch
+                    .checked=${this._show_attribute}
+                    .configValue=${'show_attribute'}
                     @change=${this._valueChanged}
                   ></ha-switch>
                 </ha-formfield>

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -9,9 +9,11 @@
     "general": {
       "title": "General",
       "entity": "Entity (Required)",
+      "attribute": "Attribute (Optional)",
       "name": "Name (Optional)",
       "show_name": "Show name?",
       "show_state": "Show state?",
+      "show_attribute": "Show attribute?",
       "compact": "Compact?"
     },
     "icon": {

--- a/src/slider-button-card.ts
+++ b/src/slider-button-card.ts
@@ -204,13 +204,14 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
                       ` : html`
                       ${this.ctrl.label}
                     `}
-                  </span>`
+                  </span>
+                  `
                   : ''}
 
               ${this.config.show_attribute
                 ? html`
                   <span class="attribute">
-                  ${this.config.show_state
+                  ${this.config.show_state && this.ctrl.attributeLabel
                     ? html `  ·  `
                     : ''}
                 ${this.ctrl.attributeLabel}
@@ -642,7 +643,6 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
       white-space: nowrap;
       text-shadow: var(--state-text-shadow);
       transition: font-size 0.1s ease-in-out;
-      max-width: calc(100% - 2em);
     }
     
     /* --- SLIDER --- */    

--- a/src/slider-button-card.ts
+++ b/src/slider-button-card.ts
@@ -184,7 +184,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
   }
 
   private renderText(): TemplateResult {
-    if (!this.config.show_name && !this.config.show_state) {
+    if (!this.config.show_name && !this.config.show_state && !this.config.show_attribute) {
       return html``;
     }
     return html`
@@ -193,17 +193,28 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
               ? html`
                 <div class="name">${this.ctrl.name}</div>
                 `
-                : ''}
-            ${this.config.show_state
-              ? html`
-                <div class="state">
-                  ${this.ctrl.isUnavailable
-                  ? html`
-                    ${this.hass.localize('state.default.unavailable')}
-                    ` : html`
-                    ${this.ctrl.label}
-                  `}
-                </div>
+              : ''}
+
+              ${this.config.show_state
+                ? html`
+                  <span class="state">
+                    ${this.ctrl.isUnavailable
+                    ? html`
+                      ${this.hass.localize('state.default.unavailable')}
+                      ` : html`
+                      ${this.ctrl.label}
+                    `}
+                  </span>`
+                  : ''}
+
+              ${this.config.show_attribute
+                ? html`
+                  <span class="attribute">
+                  ${this.config.show_state
+                    ? html `  ·  `
+                    : ''}
+                ${this.ctrl.attributeLabel}
+                  </span>
                 `
                 : ''}
           </div>
@@ -623,6 +634,16 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
       overflow: hidden;
     }
     
+    /* --- ATTRIBUTE --- */
+
+    .attribute {      
+      color: var(--state-color-on, var(--label-badge-text-color, white));      
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-shadow: var(--state-text-shadow);
+      transition: font-size 0.1s ease-in-out;
+      max-width: calc(100% - 2em);
+    }
     
     /* --- SLIDER --- */    
     

--- a/src/slider-button-card.ts
+++ b/src/slider-button-card.ts
@@ -195,6 +195,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
                 `
               : ''}
 
+              <span class="oneliner">
               ${this.config.show_state
                 ? html`
                   <span class="state">
@@ -218,6 +219,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
                   </span>
                 `
                 : ''}
+              </span>
           </div>
     `;
   }
@@ -593,7 +595,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
     /* --- LABEL --- */
     
     .name {
-      color: var(--label-color-on, var(--primary-text-color, white));      
+      color: var(--label-color-on, var(--primary-text-color, white));
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
@@ -614,7 +616,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
     /* --- STATE --- */
     
     .state {      
-      color: var(--state-color-on, var(--label-badge-text-color, white));      
+      color: var(--state-color-on, var(--label-badge-text-color, white));
       text-overflow: ellipsis;
       white-space: nowrap;
       text-shadow: var(--state-text-shadow);
@@ -638,13 +640,29 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
     /* --- ATTRIBUTE --- */
 
     .attribute {      
-      color: var(--state-color-on, var(--label-badge-text-color, white));      
+      /*
+      color: var(--state-color-on, var(--label-badge-text-color, white));
       text-overflow: ellipsis;
+      overflow: hidden;
       white-space: nowrap;
       text-shadow: var(--state-text-shadow);
+      max-width: calc(50% -2em);
       transition: font-size 0.1s ease-in-out;
+      border: 1px solid red; 
+      */
     }
-    
+
+    .oneliner {      
+      color: var(--state-color-on, var(--label-badge-text-color, white));
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      max-width:  20px;
+      width: 20px;
+      text-shadow: var(--state-text-shadow);
+      transition: font-size 0.1s ease-in-out;
+      /*border: 1px solid blue;*/
+    }
     /* --- SLIDER --- */    
     
     .slider {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ declare global {
 export interface SliderButtonCardConfig extends LovelaceCardConfig {
   type: string;
   entity: string;
+  attribute?: string;
   name?: string;
   show_name?: boolean;
   show_state?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface SliderButtonCardConfig extends LovelaceCardConfig {
   name?: string;
   show_name?: boolean;
   show_state?: boolean;
+  show_attribute?: boolean;
   icon?: IconConfig;
   action_button?: ActionButtonConfig;
   slider?: SliderConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: false,
     toggle_on_click: false,
     force_square: false,
+    show_attribute: false,
   }],
   [Domain.FAN, {
     direction: SliderDirections.LEFT_RIGHT,
@@ -131,6 +132,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: false,
     toggle_on_click: false,
     force_square: false,
+    show_attribute: false,
   }],
   [Domain.SWITCH, {
     direction: SliderDirections.LEFT_RIGHT,
@@ -140,6 +142,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: false,
     toggle_on_click: true,
     force_square: false,
+    show_attribute: false,
   }],
   [Domain.COVER, {
     direction: SliderDirections.TOP_BOTTOM,
@@ -150,6 +153,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: false,
     force_square: false,
     invert: true,
+    show_attribute: false,
   }],
   [Domain.INPUT_BOOLEAN, {
     direction: SliderDirections.LEFT_RIGHT,
@@ -159,6 +163,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: false,
     toggle_on_click: true,
     force_square: false,
+    show_attribute: false,
   }],
   [Domain.MEDIA_PLAYER, {
     direction: SliderDirections.LEFT_RIGHT,
@@ -168,6 +173,8 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: true,
     toggle_on_click: false,
     force_square: false,
+    show_attribute: true,
+    attribute: "media_title",
   }],
   [Domain.LOCK, {
     direction: SliderDirections.LEFT_RIGHT,
@@ -177,6 +184,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: false,
     toggle_on_click: true,
     force_square: false,
+    show_attribute: false,
   }],
   [Domain.CLIMATE, {
     direction: SliderDirections.LEFT_RIGHT,
@@ -186,6 +194,7 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     show_track: true,
     toggle_on_click: false,
     force_square: false,
+    show_attribute: false,
   }],
 ]);
 


### PR DESCRIPTION
Creating a new branch and PR since I can't fix the merge conflicts on @lizsugar's original PR (#8). Rebases their branch on top of mainline and then includes includes a doc update.

> You can now define, via GUI or YAML, whether an attribute is to be displayed and which attribute to show.  
> 
> ![image](https://user-images.githubusercontent.com/187255/166076778-9f94bc42-45dc-4f86-a9e4-4bf5a3450db4.png)
> 
> This resolves the request in #175 and #158
> 
> ![image](https://user-images.githubusercontent.com/187255/166076884-111494c4-7b9e-427f-a72c-38bb70c68d22.png)
> 