### PR TITLE
[feat] Add Support for input_number domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Release][releases-shield]][releases]
 [![hacs_badge](https://img.shields.io/badge/HACS-default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
-A button card with integrated slider for `automation, light, switch, fan, cover, input_boolean, media_player, climate, lock` entities.
+A button card with integrated slider for `automation, light, switch, fan, cover, input_boolean, input_number, media_player, climate, lock` entities.
 
 ![Preview][preview]
 ![Preview 2][preview-2]
@@ -71,7 +71,7 @@ Slider Button Card supports Lovelace's Visual Editor.
 | Name              | Type    | Requirement  | Description                                 | Default             |
 | ----------------- | ------- | ------------ | ------------------------------------------- | ------------------- |
 | type              | string  | **Required** | `custom:slider-button-card`                   |
-| entity            | string  | **Required** | HA entity ID from domain `automation, light, switch, fan, cover, input_boolean, media_player, climate, lock`                   |               |
+| entity            | string  | **Required** | HA entity ID from domain `automation, light, switch, fan, cover, input_boolean, input_number, media_player, climate, lock`                   |               |
 | name              | string  | **Optional** | Name                                   | `entity.friendly_name`       |
 | show_attribute        | boolean | **Optional** | Show attribute  | `false` (except for `media_player` entities)            |
 | show_name        | boolean | **Optional** | Show name  | `true`             |

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -242,7 +242,7 @@ export abstract class Controller {
 
   moveSlider(event: any, {left, top, width, height}): number {
     let percentage = this.calcMovementPercentage(event, {left, top, width, height});
-    percentage = this.applyStep(percentage);
+    //percentage = this.applyStep(percentage);
     percentage = normalize(percentage, 0, 100);
     if (!this.isValuePercentage) {
       percentage = percentageToValue(percentage, this.min, this.max);
@@ -299,7 +299,10 @@ export abstract class Controller {
   }
 
   applyStep(value: number): number {
-    return  Math.round(value / this.step) * this.step;
+    this.log("applyStep value", value);
+    let rounded = Math.round(value / this.step) * this.step;
+    this.log("applyStep round", rounded);
+    return rounded;
   }
 
   log(name = '', value: string | number | object = ''): void {

--- a/src/controllers/get-controller.ts
+++ b/src/controllers/get-controller.ts
@@ -6,6 +6,7 @@ import { Controller } from './controller';
 import { CoverController } from './cover-controller';
 import { FanController } from './fan-controller';
 import { InputBooleanController } from './input-boolean-controller';
+import { InputNumberController } from './input-number-controller';
 import { LightController } from './light-controller';
 import { LockController } from './lock-controller';
 import { MediaController } from './media-controller';
@@ -21,6 +22,7 @@ export class ControllerFactory {
       [Domain.AUTOMATION]: AutomationController,
       [Domain.COVER]: CoverController,
       [Domain.INPUT_BOOLEAN]: InputBooleanController,
+      [Domain.INPUT_NUMBER]: InputNumberController,
       [Domain.MEDIA_PLAYER]: MediaController,
       [Domain.CLIMATE]: ClimateController,
       [Domain.LOCK]: LockController,

--- a/src/controllers/input-number-controller.ts
+++ b/src/controllers/input-number-controller.ts
@@ -1,15 +1,19 @@
 import { Controller } from './controller';
+import { normalize, percentageToValue, toPercentage } from '../utils';
+import { SliderConfig } from '../types';
 
 export class InputNumberController extends Controller {
   _targetValue;
   _invert = false;
+  // _min;
+  // _max;
 
   get _value(): number {
     return this.stateObj.state;
   }
 
   set _value(value) {
-    value = value / (this._max - this._min);
+    //value = percentageToValue(value, this._min, this._max);
     this._hass.callService('input_number', 'set_value', {
       // eslint-disable-next-line @typescript-eslint/camelcase
       entity_id: this.stateObj.entity_id,
@@ -25,12 +29,32 @@ export class InputNumberController extends Controller {
     return this.stateObj.attributes.max;
   }
 
+  // get _targetValue(): number {
+  //   return this._value;
+  // }
+
+  // set _targetValue(value: number) {
+  //   if (value !== this.targetValue) {
+  //     if (value > this._min) {
+  //       value = this._min;
+  //     }
+  //     if (value > this._max) {
+  //       value = this._max;
+  //     }
+  //     this._targetValue = value;
+  //   }
+  // }
+
+  get isValuePercentage(): boolean {
+    return false;
+  }
+
   get _step(): number {
     return this.stateObj.attributes.step;
   }
 
   get label(): string {
-    return `${this.value} ${this.stateObj.attributes.unit_of_measurement}`;
+    return this.stateObj.attributes.unit_of_measurement ? `${this.targetValue} ${this.stateObj.attributes.unit_of_measurement}` : `${this.targetValue}`;
   }
 
 }

--- a/src/controllers/input-number-controller.ts
+++ b/src/controllers/input-number-controller.ts
@@ -5,15 +5,12 @@ import { SliderConfig } from '../types';
 export class InputNumberController extends Controller {
   _targetValue;
   _invert = false;
-  // _min;
-  // _max;
 
   get _value(): number {
     return this.stateObj.state;
   }
 
   set _value(value) {
-    //value = percentageToValue(value, this._min, this._max);
     this._hass.callService('input_number', 'set_value', {
       // eslint-disable-next-line @typescript-eslint/camelcase
       entity_id: this.stateObj.entity_id,
@@ -28,22 +25,6 @@ export class InputNumberController extends Controller {
   get _max(): number {
     return this.stateObj.attributes.max;
   }
-
-  // get _targetValue(): number {
-  //   return this._value;
-  // }
-
-  // set _targetValue(value: number) {
-  //   if (value !== this.targetValue) {
-  //     if (value > this._min) {
-  //       value = this._min;
-  //     }
-  //     if (value > this._max) {
-  //       value = this._max;
-  //     }
-  //     this._targetValue = value;
-  //   }
-  // }
 
   get isValuePercentage(): boolean {
     return false;

--- a/src/controllers/input-number-controller.ts
+++ b/src/controllers/input-number-controller.ts
@@ -1,0 +1,36 @@
+import { Controller } from './controller';
+
+export class InputNumberController extends Controller {
+  _targetValue;
+  _invert = false;
+
+  get _value(): number {
+    return this.stateObj.state;
+  }
+
+  set _value(value) {
+    value = value / (this._max - this._min);
+    this._hass.callService('input_number', 'set_value', {
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      entity_id: this.stateObj.entity_id,
+      value: value,
+    });
+  }
+
+  get _min(): number {
+    return this.stateObj.attributes.min;
+  }
+
+  get _max(): number {
+    return this.stateObj.attributes.max;
+  }
+
+  get _step(): number {
+    return this.stateObj.attributes.step;
+  }
+
+  get label(): string {
+    return `${this.value} ${this.stateObj.attributes.unit_of_measurement}`;
+  }
+
+}

--- a/src/slider-button-card.ts
+++ b/src/slider-button-card.ts
@@ -91,7 +91,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
       compact: false,
       // eslint-disable-next-line @typescript-eslint/camelcase
       action_button: copy(ActionButtonConfigDefault),
-      debug: true,
+      debug: false,
       ...config
     };
     this.ctrl = ControllerFactory.getInstance(this.config);

--- a/src/slider-button-card.ts
+++ b/src/slider-button-card.ts
@@ -91,7 +91,7 @@ export class SliderButtonCard extends LitElement implements LovelaceCard {
       compact: false,
       // eslint-disable-next-line @typescript-eslint/camelcase
       action_button: copy(ActionButtonConfigDefault),
-      debug: false,
+      debug: true,
       ...config
     };
     this.ctrl = ControllerFactory.getInstance(this.config);

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export enum Domain {
   FAN = 'fan',
   COVER = 'cover',
   INPUT_BOOLEAN = 'input_boolean',
+  INPUT_NUMBER = 'input_number',
   MEDIA_PLAYER = 'media_player',
   CLIMATE = 'climate',
   LOCK = 'lock',
@@ -174,6 +175,15 @@ export const SliderConfigDefaultDomain: Map<string, SliderConfig> = new Map([
     toggle_on_click: true,
     force_square: false,
     show_attribute: false,
+  }],
+  [Domain.INPUT_NUMBER, {
+    direction: SliderDirections.LEFT_RIGHT,
+    background: SliderBackground.SOLID,
+    use_state_color: false,
+    use_percentage_bg_opacity: false,
+    show_track: false,
+    toggle_on_click: false,
+    force_square: false,
   }],
   [Domain.MEDIA_PLAYER, {
     direction: SliderDirections.LEFT_RIGHT,


### PR DESCRIPTION
Creating a new branch and PR since I can't fix the merge conflicts on @lizsugar's original PR (https://github.com/custom-cards/slider-button-card/pull/7). Rebases their branch on top of mainline and then includes includes a doc update.

> This adds support for the input_number domain and makes the entities far far easier to manage on a mobile touch display vs. the builtin entities card.
> 
> ![image](https://user-images.githubusercontent.com/187255/165844276-b7aa6a13-82f3-4b31-b040-74aa7b13cfca.png)
> 
> **One note**: There is a current oustanding bug where if the input_number._entity_.min value is not cleanly divisible by the input_number._entity_.step value, then the slider card is off by an amount. If your input_number has min = 5, max = 25, step = 5 then it will work just fine. But if the step is 2, then it will be off. This also has the side effect of changing the input_number to an "illegal" value when modified via slider-button-card. Step = 1 always works.
> 
> If anyone has any insight I would appreciate the help. Otherwise, I am submitting as is, because it is largely functional right now.
> 
> Closes #18

Closes #33