### PR TITLE
Increase precision for input_number and climate-controller

### DIFF
--- a/src/controllers/climate-controller.ts
+++ b/src/controllers/climate-controller.ts
@@ -42,7 +42,7 @@ export class ClimateController extends Controller {
     const unit = this._hass.config.unit_system.temperature;
     const mode = capitalizeFirst(this.state);
     // const current = this.stateObj.attributes?.current_temperature ? ` | ${this.stateObj.attributes.current_temperature}${unit}` : '';
-    return `${this.targetValue}${unit} | ${mode}`;
+    return `${this.targetValue.toFixed(1)}${unit} | ${mode}`;
   }
 
 }

--- a/src/controllers/input-number-controller.ts
+++ b/src/controllers/input-number-controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from './controller';
+import { stepToPrecision } from '../utils';
 
 export class InputNumberController extends Controller {
   _targetValue;
@@ -33,7 +34,10 @@ export class InputNumberController extends Controller {
   }
 
   get label(): string {
-    return this.stateObj.attributes.unit_of_measurement ? `${this.targetValue} ${this.stateObj.attributes.unit_of_measurement}` : `${this.targetValue}`;
+    return this.stateObj.attributes.unit_of_measurement ?
+      `${this.targetValue.toFixed(stepToPrecision(this.step))} 
+       ${this.stateObj.attributes.unit_of_measurement}` : `
+       ${this.targetValue.toFixed(stepToPrecision(this.step))}`;
   }
 
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,3 +61,7 @@ export const normalize = (value: number, min: number, max: number): number => {
 };
 
 export const capitalizeFirst = (s): string => (s && s[0].toUpperCase() + s.slice(1)) || "";
+
+export function stepToPrecision(step: number): number {
+	return Math.ceil(Math.log10(step)) * -1;
+}


### PR DESCRIPTION
So I tried to cleanly apply the changes I made back then to the main branch. Haven't tested this. For some reason I can't add it as custom repo in HACS anymore, because it complains about a non-compliant structure.

I also was not sure back then if this only worked for Celsius. Maybe someone using Imperial units should test it as well.

Let me know if this works and/or needs proper formatting. Would see if I can install a formatter for Typescript. I am really not web guy and just poorly hacked something together back then that worked for me. 